### PR TITLE
TRITON-2413 hagfish should notice new instances sooner

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -6,7 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
- * Copyright 2023, Spearhead Systems SRL.
+ * Copyright 2023 Spearhead Systems SRL.
  */
 
 var mod_assert = require('assert-plus');

--- a/lib/service.js
+++ b/lib/service.js
@@ -46,7 +46,7 @@ function Service(config) {
 }
 mod_util.inherits(Service, mod_events.EventEmitter);
 
-Service.prototype._trigger = function (hour, minute) {
+Service.prototype._trigger = function (hour, minute, doWrite) {
     var self = this;
 
     for (var i = 0; i < self.s_services.length; i++) {
@@ -63,7 +63,7 @@ Service.prototype._trigger = function (hour, minute) {
                 continue;
         }
 
-        srv.srv_service.trigger();
+        srv.srv_service.trigger(doWrite);
     }
 };
 
@@ -73,15 +73,21 @@ Service.prototype._resched = function () {
     var dt = new Date();
     dt.setUTCMilliseconds(0);
     /*
-     * Advance to the next minute:
+     * Advance to the next check, which happens four times per minute:
      */
     do {
         dt.setUTCSeconds(dt.getUTCSeconds() + 1);
-    } while (dt.getUTCSeconds() !== 0);
+    } while (dt.getUTCSeconds() % 15 !== 0);
+
+    /*
+     * Although we check four times a minute, we only write out the accumulated
+     * results once a minute.
+     */
+    var writeOut = dt.getUTCSeconds() === 0;
 
     setTimeout(function () {
         var dtt = new Date();
-        self._trigger(dtt.getUTCHours(), dtt.getUTCMinutes());
+        self._trigger(dtt.getUTCHours(), dtt.getUTCMinutes(), writeOut);
         self._resched();
     }, dt.valueOf() - Date.now());
 };
@@ -97,7 +103,7 @@ Service.prototype.start = function () {
      * Run tasks that should fire once at startup:
      */
     setImmediate(function () {
-        self._trigger(false, false);
+        self._trigger(false, false, true);
     });
     /*
      * Schedule first periodic execution:

--- a/lib/service.js
+++ b/lib/service.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2023, Spearhead Systems SRL.
  */
 
 var mod_assert = require('assert-plus');
@@ -83,7 +84,7 @@ Service.prototype._resched = function () {
      * Although we check four times a minute, we only write out the accumulated
      * results once a minute.
      */
-    var writeOut = dt.getUTCSeconds() === 0;
+    var writeOut = (dt.getUTCSeconds() === 0);
 
     setTimeout(function () {
         var dtt = new Date();

--- a/lib/service_gzip.js
+++ b/lib/service_gzip.js
@@ -50,8 +50,12 @@ function GzipService(log, dirname) {
 }
 mod_util.inherits(GzipService, mod_events.EventEmitter);
 
-GzipService.prototype.trigger = function () {
+GzipService.prototype.trigger = function (doWrite) {
     var self = this;
+
+    if (!doWrite) {
+        return;
+    }
 
     if (self.gs_running) {
         self.gs_queued = true;
@@ -103,7 +107,7 @@ GzipService.prototype._work = function () {
         if (self.gs_queued) {
             self.gs_log.debug('queued, rescheduling immediately');
             self.gs_queued = false;
-            self.trigger();
+            self.trigger(true);
         }
         return;
     }

--- a/lib/service_gzip.js
+++ b/lib/service_gzip.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2023 Spearhead Systems SRL.
  */
 
 var mod_path = require('path');

--- a/lib/service_usage.js
+++ b/lib/service_usage.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2023 Spearhead Systems SRL.
  */
 
 var mod_path = require('path');

--- a/lib/service_usage.js
+++ b/lib/service_usage.js
@@ -28,6 +28,8 @@ function UsageService(log, dirname) {
     self.us_dirname = dirname;
     self.us_running = false;
 
+    self.us_vm_cache = {};
+
     self.us_base_record = null;
 
     lib_common.sysinfo(function (err, sysinfo) {
@@ -45,7 +47,7 @@ function UsageService(log, dirname) {
 }
 mod_util.inherits(UsageService, mod_events.EventEmitter);
 
-UsageService.prototype.trigger = function () {
+UsageService.prototype.trigger = function (doWrite) {
     var self = this;
 
     if (!self.us_base_record) {
@@ -61,18 +63,18 @@ UsageService.prototype.trigger = function () {
 
     self.us_log.debug('triggered');
 
-    self._resched();
+    self._resched(doWrite);
 };
 
-UsageService.prototype._resched = function () {
+UsageService.prototype._resched = function (doWrite) {
     var self = this;
 
     setImmediate(function () {
-        self._work();
+        self._work(doWrite);
     });
 };
 
-UsageService.prototype._work = function () {
+UsageService.prototype._work = function (doWrite) {
     var self = this;
 
     var now = new Date();
@@ -87,6 +89,33 @@ UsageService.prototype._work = function () {
             }, 'getVirtualMachineUsage returned error');
             throw (err);
         }
+
+        /*
+         * Update cache every _work() call.
+         */
+        vms.forEach(function updateVm(_vm) {
+            self.us_vm_cache[_vm.uuid] = _vm;
+        });
+
+        /*
+         * If we're not writing, updating the cache was enough.
+         */
+        if (!doWrite) {
+            self.us_running = false;
+            self.us_log.debug({
+                summary: summary
+            }, 'caching run complete');
+
+            return;
+        }
+
+        /*
+         * Replace vms with the updated cache, then empty cache.
+         */
+        vms = Object.keys(self.us_vm_cache).map(function getVm(vmUuid) {
+            return self.us_vm_cache[vmUuid];
+        });
+        self.us_vm_cache = {};
 
         var ufw = new lib_ufw.UsageFileWriter(self.us_dirname, now);
         ufw.on('error', function (_err) {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "name": "hagfish-watcher",
     "description": "SmartDataCenter Usage Watcher Agent",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "dependencies": {
         "bunyan": "0.21.3",
         "sax": "0.5.4",
         "mkdirp": "0.3.5",
-        "kstat": "^1.0.2",
+        "kstat": "1.0.2",
         "zutil": "1.0.0",
         "extsprintf": "1.0.3",
         "vasync": "1.5.0",


### PR DESCRIPTION
Some users create very short-lived VMs (especially using Docker), which `hagfish-watcher` misses. If a VM lifetime is notably shorter than one minute, `hagfish-watcher` is likely to not notice the VM ever existing due to polling every 60s. This is particularly a problem if attempting to use hagfish results for later generating usage and/or billing: a lot of VMs fly under the radar.

This is a minimally-invasive change that makes `hagfish-watcher` check for VMs every 15s instead of every 60, but continues to write out results every 60s. It does this by maintaining an internal cache that is written to every 15s, and written (and cleared) to disk every 60s. This may not be the most elegant change, but it should minimize risk.

The main danger of checking VM status more often is querying ZFS more often, especially when there are huge numbers of VMs or snapshots. Luckily, `hagfish-watcher` already contains a mechanism so that it will not create new queries before existing ones complete. Looking at `vfsstat` and `zfs iostat` (just to be safe), I observe minimal difference when `hagfish-watcher` is doing 12-20s queries on a server with 32K snapshots every 60s versus every 5s:

```
[root@e4-43-4b-86-6c-08 (ro-1) ~]# zpool iostat 120
              capacity     operations     bandwidth
pool        alloc   free   read  write   read  write
----------  -----  -----  -----  -----  -----  -----
...
60s _resched():
zones       20.9T  3.11T      0    738    153  4.15M
zones       20.9T  3.11T      1    854    738  4.86M
zones       20.9T  3.11T      0    862  1.54K  5.06M
...
15s _resched():
zones       20.9T  3.11T      0    635    166  3.68M
zones       20.9T  3.11T      0    673     59  4.19M
zones       20.9T  3.11T      0    743  1.25K  4.58M
...
5s _resched():
zones       20.9T  3.11T      2    850  3.06K  4.49M
zones       20.9T  3.11T      3   1008  9.68K  5.23M
zones       20.9T  3.11T      6  1.00K  8.38K  5.69M


[root@e4-43-4b-86-6c-08 (ro-1) ~]# vfsstat 120
  r/s   w/s  kr/s  kw/s ractv wactv read_t writ_t  %r  %w   d/s  del_t zone
...
60s _resched():
 14.3   5.2  41.2   3.1   0.0   0.0    3.7    6.1   0   0   0.0    0.0 global (0)
 34.9   3.5  54.9   0.9   0.0   0.0    2.2    9.4   0   0   0.0    0.0 global (0)
 28.4   3.3  32.7   0.9   0.0   0.0    2.3    9.1   0   0   0.0    0.0 global (0)
...
15s _resched():
 56.0   5.6  62.9   1.5   0.0   0.0    2.0    9.5   0   0   0.0    0.0 global (0)
  9.6   1.6  38.8   0.4   0.0   0.0    4.6   14.2   0   0   0.0    0.0 global (0)
 32.5   5.3  34.5   1.2   0.0   0.0    2.2   10.0   0   0   0.0    0.0 global (0)
...
5s _resched():
 56.4   5.8  49.6   1.5   0.0   0.0    8.0   11.5   0   0   0.0    0.0 global (0)
 11.3   2.0  35.5   0.3   0.0   0.0    4.4   16.1   0   0   0.0    0.0 global (0)
 40.4   5.6  60.4   1.2   0.0   0.0    2.1   11.2   0   0   0.0    0.0 global (0)
```

This patch has been used in production, although I've made some minor cleanups since then.